### PR TITLE
Adiciona funcionalidade de alternar entre temas claro e escuro

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'models/counter_model.dart';
+import 'models/theme_model.dart';
 import 'screens/home_screen.dart';
 
 void main() {
   runApp(
-    ChangeNotifierProvider(
-      create: (context) => CounterModel(),
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (context) => CounterModel()),
+        ChangeNotifierProvider(create: (context) => ThemeModel()),
+      ],
       child: const MyApp(),
     ),
   );
@@ -17,10 +21,22 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Consumindo o ThemeModel para obter o modo de tema atual
+    final themeModel = context.watch<ThemeModel>();
+    
     return MaterialApp(
       title: 'Flutter Example App',
+      themeMode: themeModel.themeMode,
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
+      ),
+      darkTheme: ThemeData(
+        brightness: Brightness.dark,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.deepPurple,
+          brightness: Brightness.dark,
+        ),
         useMaterial3: true,
       ),
       home: const HomeScreen(),

--- a/lib/models/theme_model.dart
+++ b/lib/models/theme_model.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class ThemeModel with ChangeNotifier {
+  bool _isDarkMode = false;
+
+  bool get isDarkMode => _isDarkMode;
+
+  ThemeMode get themeMode => _isDarkMode ? ThemeMode.dark : ThemeMode.light;
+
+  void toggleTheme() {
+    _isDarkMode = !_isDarkMode;
+    notifyListeners();
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../models/counter_model.dart';
 import '../widgets/counter_display.dart';
 import '../widgets/counter_controls.dart';
+import '../widgets/theme_toggle.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -13,6 +14,10 @@ class HomeScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Flutter Counter Example'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        actions: const [
+          // Adicionando o botão de alternar tema na barra de navegação
+          ThemeToggle(),
+        ],
       ),
       body: Center(
         child: Column(

--- a/lib/widgets/theme_toggle.dart
+++ b/lib/widgets/theme_toggle.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/theme_model.dart';
+
+class ThemeToggle extends StatelessWidget {
+  const ThemeToggle({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ThemeModel>(
+      builder: (context, themeModel, child) {
+        return IconButton(
+          icon: Icon(
+            themeModel.isDarkMode ? Icons.light_mode : Icons.dark_mode,
+          ),
+          onPressed: () {
+            themeModel.toggleTheme();
+          },
+          tooltip: themeModel.isDarkMode ? 'Alternar para modo claro' : 'Alternar para modo escuro',
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Descrição

Esta pull request adiciona a funcionalidade de alternar entre temas claro e escuro no aplicativo.

## Alterações

- Criação de um novo modelo ThemeModel para gerenciar o estado do tema
- Atualização do arquivo main.dart para incluir o ThemeModel no Provider
- Criação de um widget ThemeToggle para alternar entre os temas
- Atualização da tela HomeScreen para incluir o botão de alternar tema

## Testes

Foram realizados testes manuais para verificar:
- Alternar entre temas claro e escuro funciona corretamente
- A interface do usuário responde ao tema atual
- O estado do tema é mantido durante o uso do aplicativo

## Screenshots

Não disponíveis nesta PR, mas a funcionalidade permite alternar entre temas claro (padrão) e escuro.